### PR TITLE
fix AMO auth timestamp and key issues

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -4,7 +4,11 @@ import shutil
 from datetime import datetime
 from jwcrypto.jwt import JWT
 from jwcrypto.jwk import JWK
+import base64
+from math import floor
 import uuid
+import requests
+import sys
 
 def rmDir(path):
   if os.path.exists(path):
@@ -30,14 +34,29 @@ def saveJson(path, data):
     json.dump(data, f, indent=3)
 
 def generateToken(issuer, key):
-  timestamp = round(datetime.utcnow().timestamp())
+  timestamp = floor(datetime.now().timestamp())
   data = {
     'iss': issuer,
     'iat': timestamp,
     'exp': timestamp + 300,
     'jti': str(uuid.uuid4())
   }
-  jwk = JWK(k=key, kty='oct')
+  key_b64 = (
+    base64
+    .urlsafe_b64encode(key.encode('ascii'))
+    .decode()
+  )
+  jwk = JWK(
+    k=key_b64,
+    kty='oct'
+  )
   token = JWT(header={'alg': 'HS256'}, claims=data)
   token.make_signed_token(jwk)
   return token.serialize()
+
+def checkResponse(r: requests.Response):
+  try:
+    r.raise_for_status()
+  except:
+    print(r.json(), file=sys.stderr)
+    raise

--- a/publish_firefox.py
+++ b/publish_firefox.py
@@ -1,5 +1,5 @@
 import os
-from helper import readJson, generateToken
+from helper import readJson, generateToken, checkResponse
 import requests
 import shutil
 
@@ -25,6 +25,7 @@ token = generateToken(os.environ['MOZILLA_API_KEY'], os.environ['MOZILLA_API_SEC
 # check if version exists
 print('Checking if version exists...')
 r = requests.get(f'https://addons.mozilla.org/api/v5/addons/addon/{uuid}/versions/', headers={'Authorization': f'JWT {token}'})
+checkResponse(r)
 version_result = r.json()
 previous_versions = [v['version'] for v in version_result['results']]
 
@@ -35,6 +36,7 @@ if not version in previous_versions:
   print('Uploading new version...')
   files = {'upload': open(tmp_dir + '/firefox_addon.zip', 'rb')}
   r = requests.post(f'https://addons.mozilla.org/api/v5/addons/{uuid}/versions/{version}', headers={'Authorization': f'JWT {token}'}, files=files)
+  checkResponse(r)
   print('Uploaded new version:')
   print(r.text)
 else:


### PR DESCRIPTION
This should probably fix #3 (it was needed when running here), and make future problems a little clearer.
N.B. I'm not sure if the key changes are breaking for you - I'm running by copy-pasting my AMO key straight into an env file that looks like
```
MOZILLA_API_KEY=user:12132989:***
MOZILLA_API_SECRET=abc...
```
and running with
```
env $(cat environment) python ./publish_firefox.py
```
.

If you've pre-encoded your API secret in Github or something then this would be a breaking change for you (but it would mean you can copy future keys straight in from the AMO page without doing anything to the first). I can't really tell sorry because I can't see your CI secrets :)